### PR TITLE
Abstract services regenerated because of pagination problem

### DIFF
--- a/config/model-binding.php
+++ b/config/model-binding.php
@@ -141,5 +141,29 @@ return [
         return NextDeveloper\Partnership\Database\Models\PartnershipAccount::findByRef($value);
 },
 
+'partnershipdistribution' => function ($value) {
+        return NextDeveloper\Partnership\Database\Models\PartnershipDistribution::findByRef($value);
+},
+
+'partnershipmarketing' => function ($value) {
+        return NextDeveloper\Partnership\Database\Models\PartnershipMarketing::findByRef($value);
+},
+
+'partnershipproduction' => function ($value) {
+        return NextDeveloper\Partnership\Database\Models\PartnershipProduction::findByRef($value);
+},
+
+'partnershipstat' => function ($value) {
+        return NextDeveloper\Partnership\Database\Models\PartnershipStat::findByRef($value);
+},
+
+'partnershipaccount' => function ($value) {
+        return NextDeveloper\Partnership\Database\Models\PartnershipAccount::findByRef($value);
+},
+
+'partnershipaffiliate' => function ($value) {
+        return NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::findByRef($value);
+},
+
 // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 ];

--- a/src/Database/Filters/AccountsQueryFilter.php
+++ b/src/Database/Filters/AccountsQueryFilter.php
@@ -136,4 +136,5 @@ class AccountsQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Filters/AffiliatesQueryFilter.php
+++ b/src/Database/Filters/AffiliatesQueryFilter.php
@@ -55,7 +55,7 @@ class AffiliatesQueryFilter extends AbstractQueryFilter
 
     public function partnerAccountId($value)
     {
-            $partnerAccount = \NextDeveloper\Database\Models\PartnerAccounts::where('uuid', $value)->first();
+            $partnerAccount = \NextDeveloper\\Database\Models\PartnerAccounts::where('uuid', $value)->first();
 
         if($partnerAccount) {
             return $this->builder->where('partner_account_id', '=', $partnerAccount->id);
@@ -72,4 +72,5 @@ class AffiliatesQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Filters/DistributionsQueryFilter.php
+++ b/src/Database/Filters/DistributionsQueryFilter.php
@@ -204,4 +204,5 @@ class DistributionsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/MarketingsQueryFilter.php
+++ b/src/Database/Filters/MarketingsQueryFilter.php
@@ -146,4 +146,5 @@ class MarketingsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/ProductionsQueryFilter.php
+++ b/src/Database/Filters/ProductionsQueryFilter.php
@@ -198,4 +198,5 @@ class ProductionsQueryFilter extends AbstractQueryFilter
 
 
 
+
 }

--- a/src/Database/Filters/StatsQueryFilter.php
+++ b/src/Database/Filters/StatsQueryFilter.php
@@ -44,7 +44,7 @@ class StatsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('visitor_count', $operator, $value);
     }
 
-    public function AffiliateCount($value)
+    public function customerCount($value)
     {
         $operator = substr($value, 0, 1);
 
@@ -133,4 +133,5 @@ class StatsQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Models/Accounts.php
+++ b/src/Database/Models/Accounts.php
@@ -168,4 +168,5 @@ class Accounts extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Models/Affiliates.php
+++ b/src/Database/Models/Affiliates.php
@@ -10,9 +10,10 @@ use NextDeveloper\Partnership\Database\Observers\CustomersObserver;
 use NextDeveloper\Commons\Database\Traits\UuidId;
 use NextDeveloper\Commons\Common\Cache\Traits\CleanCache;
 use NextDeveloper\Commons\Database\Traits\Taggable;
+use NextDeveloper\Partnership\Database\Observers\AffiliatesObserver;
 
 /**
- * Customers model.
+ * Affiliates model.
  *
  * @package  NextDeveloper\Partnership\Database\Models
  * @property integer $id
@@ -105,7 +106,7 @@ class Affiliates extends Model
         parent::boot();
 
         //  We create and add Observer even if we wont use it.
-        parent::observe(CustomersObserver::class);
+        parent::observe(AffiliatesObserver::class);
 
         self::registerScopes();
     }
@@ -113,7 +114,7 @@ class Affiliates extends Model
     public static function registerScopes()
     {
         $globalScopes = config('partnership.scopes.global');
-        $modelScopes = config('partnership.scopes.partnership_customers');
+        $modelScopes = config('partnership.scopes.partnership_affiliates');
 
         if(!$modelScopes) { $modelScopes = [];
         }
@@ -133,4 +134,5 @@ class Affiliates extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Models/Distributions.php
+++ b/src/Database/Models/Distributions.php
@@ -48,7 +48,7 @@ class Distributions extends Model
 
     public $timestamps = true;
 
-    protected $table = 'partnership_distribution';
+    protected $table = 'partnership_distributions';
 
 
     /**
@@ -162,7 +162,7 @@ class Distributions extends Model
     public static function registerScopes()
     {
         $globalScopes = config('partnership.scopes.global');
-        $modelScopes = config('partnership.scopes.partnership_distribution');
+        $modelScopes = config('partnership.scopes.partnership_distributions');
 
         if(!$modelScopes) { $modelScopes = [];
         }
@@ -182,6 +182,7 @@ class Distributions extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Database/Models/Marketings.php
+++ b/src/Database/Models/Marketings.php
@@ -44,7 +44,7 @@ class Marketings extends Model
 
     public $timestamps = true;
 
-    protected $table = 'partnership_marketing';
+    protected $table = 'partnership_marketings';
 
 
     /**
@@ -149,7 +149,7 @@ class Marketings extends Model
     public static function registerScopes()
     {
         $globalScopes = config('partnership.scopes.global');
-        $modelScopes = config('partnership.scopes.partnership_marketing');
+        $modelScopes = config('partnership.scopes.partnership_marketings');
 
         if(!$modelScopes) { $modelScopes = [];
         }
@@ -169,6 +169,7 @@ class Marketings extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Database/Models/Productions.php
+++ b/src/Database/Models/Productions.php
@@ -47,7 +47,7 @@ class Productions extends Model
 
     public $timestamps = true;
 
-    protected $table = 'partnership_production';
+    protected $table = 'partnership_productions';
 
 
     /**
@@ -159,7 +159,7 @@ class Productions extends Model
     public static function registerScopes()
     {
         $globalScopes = config('partnership.scopes.global');
-        $modelScopes = config('partnership.scopes.partnership_production');
+        $modelScopes = config('partnership.scopes.partnership_productions');
 
         if(!$modelScopes) { $modelScopes = [];
         }
@@ -179,6 +179,7 @@ class Productions extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Database/Models/Stats.php
+++ b/src/Database/Models/Stats.php
@@ -147,4 +147,5 @@ class Stats extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Observers/AffiliatesObserver.php
+++ b/src/Database/Observers/AffiliatesObserver.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace NextDeveloper\Partnership\Database\Observers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use NextDeveloper\IAM\Helpers\UserHelper;
+
+/**
+ * Class AffiliatesObserver
+ *
+ * @package NextDeveloper\Partnership\Database\Observers
+ */
+class AffiliatesObserver
+{
+    /**
+     * Triggered when a new record is retrieved.
+     *
+     * @param Model $model
+     */
+    public function retrieved(Model $model)
+    {
+
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function creating(Model $model)
+    {
+        return UserHelper::applyUserFields($model);
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function created(Model $model)
+    {
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function saving(Model $model)
+    {
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function saved(Model $model)
+    {
+    }
+
+
+    /**
+     * @param Model $model
+     */
+    public function updating(Model $model)
+    {
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function updated(Model $model)
+    {
+    }
+
+
+    /**
+     * @param Model $model
+     */
+    public function deleting(Model $model)
+    {
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function deleted(Model $model)
+    {
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function restoring(Model $model)
+    {
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return mixed
+     */
+    public function restored(Model $model)
+    {
+    }
+    // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+}

--- a/src/Http/Requests/Affiliates/AffiliatesCreateRequest.php
+++ b/src/Http/Requests/Affiliates/AffiliatesCreateRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace NextDeveloper\Partnership\Http\Requests\Accounts;
+namespace NextDeveloper\Partnership\Http\Requests\Affiliates;
 
 use NextDeveloper\Commons\Http\Requests\AbstractFormRequest;
 
-class AccountsCreateRequest extends AbstractFormRequest
+class AffiliatesCreateRequest extends AbstractFormRequest
 {
 
     /**
@@ -13,9 +13,9 @@ class AccountsCreateRequest extends AbstractFormRequest
     public function rules()
     {
         return [
-            'distributor_id' => 'nullable|exists:iam_accounts,uuid|uuid',
+            'partner_account_id' => 'required|exists:partner_accounts,uuid|uuid',
+        'is_active' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
-
 }

--- a/src/Http/Requests/Affiliates/AffiliatesUpdateRequest.php
+++ b/src/Http/Requests/Affiliates/AffiliatesUpdateRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace NextDeveloper\Partnership\Http\Requests\Accounts;
+namespace NextDeveloper\Partnership\Http\Requests\Affiliates;
 
 use NextDeveloper\Commons\Http\Requests\AbstractFormRequest;
 
-class AccountsCreateRequest extends AbstractFormRequest
+class AffiliatesUpdateRequest extends AbstractFormRequest
 {
 
     /**
@@ -13,9 +13,9 @@ class AccountsCreateRequest extends AbstractFormRequest
     public function rules()
     {
         return [
-            'distributor_id' => 'nullable|exists:iam_accounts,uuid|uuid',
+            'partner_account_id' => 'nullable|exists:partner_accounts,uuid|uuid',
+        'is_active' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
-
 }

--- a/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Partnership\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Partnership\Database\Models\Accounts;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class AccountsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractAccountsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Accounts $model
      *
      * @return array
      */
     public function transform(Accounts $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $distributorId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->distributor_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $distributorId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->distributor_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -48,5 +82,89 @@ class AbstractAccountsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Accounts $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Accounts $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Accounts $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Accounts $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Accounts $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Accounts $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Accounts $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Accounts $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Accounts $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Http/Transformers/AbstractTransformers/AbstractAffiliatesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAffiliatesTransformer.php
@@ -2,8 +2,6 @@
 
 namespace NextDeveloper\Partnership\Http\Transformers\AbstractTransformers;
 
-use NextDeveloper\Partnership\Database\Models\Marketings;
-use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
 use NextDeveloper\Commons\Database\Models\Addresses;
 use NextDeveloper\Commons\Database\Models\Comments;
 use NextDeveloper\Commons\Database\Models\Meta;
@@ -22,14 +20,16 @@ use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
 use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
 use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
 use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\Partnership\Database\Models\Affiliates;
+use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
 use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
- * Class MarketingsTransformer. This class is being used to manipulate the data we are serving to the customer
+ * Class AffiliatesTransformer. This class is being used to manipulate the data we are serving to the customer
  *
  * @package NextDeveloper\Partnership\Http\Transformers
  */
-class AbstractMarketingsTransformer extends AbstractTransformer
+class AbstractAffiliatesTransformer extends AbstractTransformer
 {
 
     /**
@@ -48,32 +48,21 @@ class AbstractMarketingsTransformer extends AbstractTransformer
     ];
 
     /**
-     * @param Marketings $model
+     * @param Affiliates $model
      *
      * @return array
      */
-    public function transform(Marketings $model)
+    public function transform(Affiliates $model)
     {
-                                                $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
+                                                $partnerAccountId = \NextDeveloper\\Database\Models\PartnerAccounts::where('id', $model->partner_account_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                         
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
+            'partner_account_id'  =>  $partnerAccountId ? $partnerAccountId->uuid : null,
+            'iam_account_id'  =>  $iamAccountId ? $iamAccountId->uuid : null,
             'is_active'  =>  $model->is_active,
-            'is_suspended'  =>  $model->is_suspended,
-            'is_draft'  =>  $model->is_draft,
-            'is_affiliate'  =>  $model->is_affiliate,
-            'is_content_marketing'  =>  $model->is_content_marketing,
-            'is_co_branding'  =>  $model->is_co_branding,
-            'is_co_marketing'  =>  $model->is_co_marketing,
-            'is_sponsorship'  =>  $model->is_sponsorship,
-            'is_incentive'  =>  $model->is_incentive,
-            'is_referral'  =>  $model->is_referral,
-            'incentive_percentage'  =>  $model->incentive_percentage,
-            'description'  =>  $model->description,
-            'terms'  =>  $model->terms,
-            'tags'  =>  $model->tags,
-            'partnership_account_id'  =>  $partnershipAccountId ? $partnershipAccountId->uuid : null,
             'created_at'  =>  $model->created_at,
             'updated_at'  =>  $model->updated_at,
             'deleted_at'  =>  $model->deleted_at,
@@ -81,7 +70,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         );
     }
 
-    public function includeStates(Marketings $model)
+    public function includeStates(Affiliates $model)
     {
         $states = States::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -90,7 +79,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($states, new StatesTransformer());
     }
 
-    public function includeActions(Marketings $model)
+    public function includeActions(Affiliates $model)
     {
         $input = get_class($model);
         $input = str_replace('\\Database\\Models', '', $input);
@@ -102,7 +91,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($actions, new AvailableActionsTransformer());
     }
 
-    public function includeMedia(Marketings $model)
+    public function includeMedia(Affiliates $model)
     {
         $media = Media::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -111,7 +100,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($media, new MediaTransformer());
     }
 
-    public function includeSocialMedia(Marketings $model)
+    public function includeSocialMedia(Affiliates $model)
     {
         $socialMedia = SocialMedia::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -120,7 +109,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($socialMedia, new SocialMediaTransformer());
     }
 
-    public function includeComments(Marketings $model)
+    public function includeComments(Affiliates $model)
     {
         $comments = Comments::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -129,7 +118,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($comments, new CommentsTransformer());
     }
 
-    public function includeVotes(Marketings $model)
+    public function includeVotes(Affiliates $model)
     {
         $votes = Votes::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -138,7 +127,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($votes, new VotesTransformer());
     }
 
-    public function includeMeta(Marketings $model)
+    public function includeMeta(Affiliates $model)
     {
         $meta = Meta::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -147,7 +136,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($meta, new MetaTransformer());
     }
 
-    public function includePhoneNumbers(Marketings $model)
+    public function includePhoneNumbers(Affiliates $model)
     {
         $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -156,7 +145,7 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
     }
 
-    public function includeAddresses(Marketings $model)
+    public function includeAddresses(Affiliates $model)
     {
         $addresses = Addresses::where('object_type', get_class($model))
             ->where('object_id', $model->id)
@@ -165,15 +154,4 @@ class AbstractMarketingsTransformer extends AbstractTransformer
         return $this->collection($addresses, new AddressesTransformer());
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/src/Http/Transformers/AbstractTransformers/AbstractDistributionsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractDistributionsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Partnership\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Partnership\Database\Models\Distributions;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class DistributionsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,14 +33,29 @@ class AbstractDistributionsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Distributions $model
      *
      * @return array
      */
     public function transform(Distributions $model)
     {
-                        $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
-        
+                                                $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -51,7 +85,91 @@ class AbstractDistributionsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Distributions $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Distributions $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Distributions $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Distributions $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Distributions $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Distributions $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Distributions $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Distributions $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Distributions $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductionsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductionsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Partnership\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Partnership\Database\Models\Productions;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class ProductionsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,14 +33,29 @@ class AbstractProductionsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Productions $model
      *
      * @return array
      */
     public function transform(Productions $model)
     {
-                        $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
-        
+                                                $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -50,7 +84,91 @@ class AbstractProductionsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Productions $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Productions $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Productions $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Productions $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Productions $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Productions $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Productions $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Productions $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Productions $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractStatsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractStatsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Partnership\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Partnership\Database\Models\Stats;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class StatsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,14 +33,29 @@ class AbstractStatsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Stats $model
      *
      * @return array
      */
     public function transform(Stats $model)
     {
-                        $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
-        
+                                                $partnershipAccountId = \NextDeveloper\Partnership\Database\Models\Accounts::where('id', $model->partnership_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -39,5 +73,89 @@ class AbstractStatsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Stats $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Stats $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Stats $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Stats $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Stats $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Stats $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Stats $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Stats $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Stats $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Http/Transformers/AffiliatesTransformer.php
+++ b/src/Http/Transformers/AffiliatesTransformer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace NextDeveloper\Partnership\Http\Transformers;
+
+use Illuminate\Support\Facades\Cache;
+use NextDeveloper\Commons\Common\Cache\CacheHelper;
+use NextDeveloper\Partnership\Database\Models\Affiliates;
+use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Partnership\Http\Transformers\AbstractTransformers\AbstractAffiliatesTransformer;
+
+/**
+ * Class AffiliatesTransformer. This class is being used to manipulate the data we are serving to the customer
+ *
+ * @package NextDeveloper\Partnership\Http\Transformers
+ */
+class AffiliatesTransformer extends AbstractAffiliatesTransformer
+{
+
+    /**
+     * @param Affiliates $model
+     *
+     * @return array
+     */
+    public function transform(Affiliates $model)
+    {
+        $transformed = Cache::get(
+            CacheHelper::getKey('Affiliates', $model->uuid, 'Transformed')
+        );
+
+        if($transformed) {
+            return $transformed;
+        }
+
+        $transformed = parent::transform($model);
+
+        Cache::set(
+            CacheHelper::getKey('Affiliates', $model->uuid, 'Transformed'),
+            $transformed
+        );
+
+        return $transformed;
+    }
+}

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -2,66 +2,66 @@
 
 Route::prefix('partnership')->group(
     function () {
-        Route::prefix('marketing')->group(
+        Route::prefix('distributions')->group(
             function () {
-                Route::get('/', 'Marketing\MarketingController@index');
-                Route::get('/actions', 'Marketing\MarketingController@getActions');
+                Route::get('/', 'Distributions\DistributionsController@index');
+                Route::get('/actions', 'Distributions\DistributionsController@getActions');
 
-                Route::get('{partnership_marketing}/tags ', 'Marketing\MarketingController@tags');
-                Route::post('{partnership_marketing}/tags ', 'Marketing\MarketingController@saveTags');
-                Route::get('{partnership_marketing}/addresses ', 'Marketing\MarketingController@addresses');
-                Route::post('{partnership_marketing}/addresses ', 'Marketing\MarketingController@saveAddresses');
+                Route::get('{partnership_distributions}/tags ', 'Distributions\DistributionsController@tags');
+                Route::post('{partnership_distributions}/tags ', 'Distributions\DistributionsController@saveTags');
+                Route::get('{partnership_distributions}/addresses ', 'Distributions\DistributionsController@addresses');
+                Route::post('{partnership_distributions}/addresses ', 'Distributions\DistributionsController@saveAddresses');
 
-                Route::get('/{partnership_marketing}/{subObjects}', 'Marketing\MarketingController@relatedObjects');
-                Route::get('/{partnership_marketing}', 'Marketing\MarketingController@show');
+                Route::get('/{partnership_distributions}/{subObjects}', 'Distributions\DistributionsController@relatedObjects');
+                Route::get('/{partnership_distributions}', 'Distributions\DistributionsController@show');
 
-                Route::post('/', 'Marketing\MarketingController@store');
-                Route::post('/{partnership_marketing}/do/{action}', 'Marketing\MarketingController@doAction');
+                Route::post('/', 'Distributions\DistributionsController@store');
+                Route::post('/{partnership_distributions}/do/{action}', 'Distributions\DistributionsController@doAction');
 
-                Route::patch('/{partnership_marketing}', 'Marketing\MarketingController@update');
-                Route::delete('/{partnership_marketing}', 'Marketing\MarketingController@destroy');
+                Route::patch('/{partnership_distributions}', 'Distributions\DistributionsController@update');
+                Route::delete('/{partnership_distributions}', 'Distributions\DistributionsController@destroy');
             }
         );
 
-        Route::prefix('distribution')->group(
+        Route::prefix('marketings')->group(
             function () {
-                Route::get('/', 'Distribution\DistributionController@index');
-                Route::get('/actions', 'Distribution\DistributionController@getActions');
+                Route::get('/', 'Marketings\MarketingsController@index');
+                Route::get('/actions', 'Marketings\MarketingsController@getActions');
 
-                Route::get('{partnership_distribution}/tags ', 'Distribution\DistributionController@tags');
-                Route::post('{partnership_distribution}/tags ', 'Distribution\DistributionController@saveTags');
-                Route::get('{partnership_distribution}/addresses ', 'Distribution\DistributionController@addresses');
-                Route::post('{partnership_distribution}/addresses ', 'Distribution\DistributionController@saveAddresses');
+                Route::get('{partnership_marketings}/tags ', 'Marketings\MarketingsController@tags');
+                Route::post('{partnership_marketings}/tags ', 'Marketings\MarketingsController@saveTags');
+                Route::get('{partnership_marketings}/addresses ', 'Marketings\MarketingsController@addresses');
+                Route::post('{partnership_marketings}/addresses ', 'Marketings\MarketingsController@saveAddresses');
 
-                Route::get('/{partnership_distribution}/{subObjects}', 'Distribution\DistributionController@relatedObjects');
-                Route::get('/{partnership_distribution}', 'Distribution\DistributionController@show');
+                Route::get('/{partnership_marketings}/{subObjects}', 'Marketings\MarketingsController@relatedObjects');
+                Route::get('/{partnership_marketings}', 'Marketings\MarketingsController@show');
 
-                Route::post('/', 'Distribution\DistributionController@store');
-                Route::post('/{partnership_distribution}/do/{action}', 'Distribution\DistributionController@doAction');
+                Route::post('/', 'Marketings\MarketingsController@store');
+                Route::post('/{partnership_marketings}/do/{action}', 'Marketings\MarketingsController@doAction');
 
-                Route::patch('/{partnership_distribution}', 'Distribution\DistributionController@update');
-                Route::delete('/{partnership_distribution}', 'Distribution\DistributionController@destroy');
+                Route::patch('/{partnership_marketings}', 'Marketings\MarketingsController@update');
+                Route::delete('/{partnership_marketings}', 'Marketings\MarketingsController@destroy');
             }
         );
 
-        Route::prefix('production')->group(
+        Route::prefix('productions')->group(
             function () {
-                Route::get('/', 'Production\ProductionController@index');
-                Route::get('/actions', 'Production\ProductionController@getActions');
+                Route::get('/', 'Productions\ProductionsController@index');
+                Route::get('/actions', 'Productions\ProductionsController@getActions');
 
-                Route::get('{partnership_production}/tags ', 'Production\ProductionController@tags');
-                Route::post('{partnership_production}/tags ', 'Production\ProductionController@saveTags');
-                Route::get('{partnership_production}/addresses ', 'Production\ProductionController@addresses');
-                Route::post('{partnership_production}/addresses ', 'Production\ProductionController@saveAddresses');
+                Route::get('{partnership_productions}/tags ', 'Productions\ProductionsController@tags');
+                Route::post('{partnership_productions}/tags ', 'Productions\ProductionsController@saveTags');
+                Route::get('{partnership_productions}/addresses ', 'Productions\ProductionsController@addresses');
+                Route::post('{partnership_productions}/addresses ', 'Productions\ProductionsController@saveAddresses');
 
-                Route::get('/{partnership_production}/{subObjects}', 'Production\ProductionController@relatedObjects');
-                Route::get('/{partnership_production}', 'Production\ProductionController@show');
+                Route::get('/{partnership_productions}/{subObjects}', 'Productions\ProductionsController@relatedObjects');
+                Route::get('/{partnership_productions}', 'Productions\ProductionsController@show');
 
-                Route::post('/', 'Production\ProductionController@store');
-                Route::post('/{partnership_production}/do/{action}', 'Production\ProductionController@doAction');
+                Route::post('/', 'Productions\ProductionsController@store');
+                Route::post('/{partnership_productions}/do/{action}', 'Productions\ProductionsController@doAction');
 
-                Route::patch('/{partnership_production}', 'Production\ProductionController@update');
-                Route::delete('/{partnership_production}', 'Production\ProductionController@destroy');
+                Route::patch('/{partnership_productions}', 'Productions\ProductionsController@update');
+                Route::delete('/{partnership_productions}', 'Productions\ProductionsController@destroy');
             }
         );
 
@@ -86,27 +86,6 @@ Route::prefix('partnership')->group(
             }
         );
 
-        Route::prefix('customers')->group(
-            function () {
-                Route::get('/', 'Customers\CustomersController@index');
-                Route::get('/actions', 'Customers\CustomersController@getActions');
-
-                Route::get('{partnership_customers}/tags ', 'Customers\CustomersController@tags');
-                Route::post('{partnership_customers}/tags ', 'Customers\CustomersController@saveTags');
-                Route::get('{partnership_customers}/addresses ', 'Customers\CustomersController@addresses');
-                Route::post('{partnership_customers}/addresses ', 'Customers\CustomersController@saveAddresses');
-
-                Route::get('/{partnership_customers}/{subObjects}', 'Customers\CustomersController@relatedObjects');
-                Route::get('/{partnership_customers}', 'Customers\CustomersController@show');
-
-                Route::post('/', 'Customers\CustomersController@store');
-                Route::post('/{partnership_customers}/do/{action}', 'Customers\CustomersController@doAction');
-
-                Route::patch('/{partnership_customers}', 'Customers\CustomersController@update');
-                Route::delete('/{partnership_customers}', 'Customers\CustomersController@destroy');
-            }
-        );
-
         Route::prefix('accounts')->group(
             function () {
                 Route::get('/', 'Accounts\AccountsController@index');
@@ -125,6 +104,27 @@ Route::prefix('partnership')->group(
 
                 Route::patch('/{partnership_accounts}', 'Accounts\AccountsController@update');
                 Route::delete('/{partnership_accounts}', 'Accounts\AccountsController@destroy');
+            }
+        );
+
+        Route::prefix('affiliates')->group(
+            function () {
+                Route::get('/', 'Affiliates\AffiliatesController@index');
+                Route::get('/actions', 'Affiliates\AffiliatesController@getActions');
+
+                Route::get('{partnership_affiliates}/tags ', 'Affiliates\AffiliatesController@tags');
+                Route::post('{partnership_affiliates}/tags ', 'Affiliates\AffiliatesController@saveTags');
+                Route::get('{partnership_affiliates}/addresses ', 'Affiliates\AffiliatesController@addresses');
+                Route::post('{partnership_affiliates}/addresses ', 'Affiliates\AffiliatesController@saveAddresses');
+
+                Route::get('/{partnership_affiliates}/{subObjects}', 'Affiliates\AffiliatesController@relatedObjects');
+                Route::get('/{partnership_affiliates}', 'Affiliates\AffiliatesController@show');
+
+                Route::post('/', 'Affiliates\AffiliatesController@store');
+                Route::post('/{partnership_affiliates}/do/{action}', 'Affiliates\AffiliatesController@doAction');
+
+                Route::patch('/{partnership_affiliates}', 'Affiliates\AffiliatesController@update');
+                Route::delete('/{partnership_affiliates}', 'Affiliates\AffiliatesController@destroy');
             }
         );
 
@@ -152,8 +152,15 @@ Route::prefix('partnership')->group(
 
 
 
+
+
+
+
+
+
     }
 );
+
 
 
 

--- a/tests/Database/Models/PartnershipAffiliateTestTraits.php
+++ b/tests/Database/Models/PartnershipAffiliateTestTraits.php
@@ -1,0 +1,517 @@
+<?php
+
+namespace NextDeveloper\Partnership\Tests\Database\Models;
+
+use Tests\TestCase;
+use GuzzleHttp\Client;
+use Illuminate\Http\Response;
+use Illuminate\Http\Request;
+use NextDeveloper\Partnership\Database\Filters\PartnershipAffiliateQueryFilter;
+use NextDeveloper\Partnership\Services\AbstractServices\AbstractPartnershipAffiliateService;
+use Illuminate\Pagination\LengthAwarePaginator;
+use League\Fractal\Resource\Collection;
+
+trait PartnershipAffiliateTestTraits
+{
+    public $http;
+
+    /**
+     *   Creating the Guzzle object
+     */
+    public function setupGuzzle()
+    {
+        $this->http = new Client(
+            [
+            'base_uri'  =>  '127.0.0.1:8000'
+            ]
+        );
+    }
+
+    /**
+     *   Destroying the Guzzle object
+     */
+    public function destroyGuzzle()
+    {
+        $this->http = null;
+    }
+
+    public function test_http_partnershipaffiliate_get()
+    {
+        $this->setupGuzzle();
+        $response = $this->http->request(
+            'GET',
+            '/partnership/partnershipaffiliate',
+            ['http_errors' => false]
+        );
+
+        $this->assertContains(
+            $response->getStatusCode(), [
+            Response::HTTP_OK,
+            Response::HTTP_NOT_FOUND
+            ]
+        );
+    }
+
+    public function test_http_partnershipaffiliate_post()
+    {
+        $this->setupGuzzle();
+        $response = $this->http->request(
+            'POST', '/partnership/partnershipaffiliate', [
+            'form_params'   =>  [
+                            ],
+                ['http_errors' => false]
+            ]
+        );
+
+        $this->assertEquals($response->getStatusCode(), Response::HTTP_OK);
+    }
+
+    /**
+     * Get test
+     *
+     * @return bool
+     */
+    public function test_partnershipaffiliate_model_get()
+    {
+        $result = AbstractPartnershipAffiliateService::get();
+
+        $this->assertIsObject($result, Collection::class);
+    }
+
+    public function test_partnershipaffiliate_get_all()
+    {
+        $result = AbstractPartnershipAffiliateService::getAll();
+
+        $this->assertIsObject($result, Collection::class);
+    }
+
+    public function test_partnershipaffiliate_get_paginated()
+    {
+        $result = AbstractPartnershipAffiliateService::get(
+            null, [
+            'paginated' =>  'true'
+            ]
+        );
+
+        $this->assertIsObject($result, LengthAwarePaginator::class);
+    }
+
+    public function test_partnershipaffiliate_event_retrieved_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateRetrievedEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_created_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateCreatedEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_creating_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateCreatingEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_saving_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateSavingEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_saved_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateSavedEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_updating_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateUpdatingEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_updated_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateUpdatedEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_deleting_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateDeletingEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_deleted_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateDeletedEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_restoring_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateRestoringEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_restored_without_object()
+    {
+        try {
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateRestoredEvent());
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_retrieved_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateRetrievedEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_created_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateCreatedEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_creating_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateCreatingEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_saving_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateSavingEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_saved_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateSavedEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_updating_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateUpdatingEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_updated_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateUpdatedEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_deleting_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateDeletingEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_deleted_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateDeletedEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_restoring_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateRestoringEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    public function test_partnershipaffiliate_event_restored_with_object()
+    {
+        try {
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::first();
+
+            event(new \NextDeveloper\Partnership\Events\PartnershipAffiliate\PartnershipAffiliateRestoredEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_created_at_filter_start()
+    {
+        try {
+            $request = new Request(
+                [
+                'created_atStart'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_updated_at_filter_start()
+    {
+        try {
+            $request = new Request(
+                [
+                'updated_atStart'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_deleted_at_filter_start()
+    {
+        try {
+            $request = new Request(
+                [
+                'deleted_atStart'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_created_at_filter_end()
+    {
+        try {
+            $request = new Request(
+                [
+                'created_atEnd'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_updated_at_filter_end()
+    {
+        try {
+            $request = new Request(
+                [
+                'updated_atEnd'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_deleted_at_filter_end()
+    {
+        try {
+            $request = new Request(
+                [
+                'deleted_atEnd'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_created_at_filter_start_and_end()
+    {
+        try {
+            $request = new Request(
+                [
+                'created_atStart'  =>  now(),
+                'created_atEnd'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_updated_at_filter_start_and_end()
+    {
+        try {
+            $request = new Request(
+                [
+                'updated_atStart'  =>  now(),
+                'updated_atEnd'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_partnershipaffiliate_event_deleted_at_filter_start_and_end()
+    {
+        try {
+            $request = new Request(
+                [
+                'deleted_atStart'  =>  now(),
+                'deleted_atEnd'  =>  now()
+                ]
+            );
+
+            $filter = new PartnershipAffiliateQueryFilter($request);
+
+            $model = \NextDeveloper\Partnership\Database\Models\PartnershipAffiliate::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+    // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+}


### PR DESCRIPTION
Abstract services regenerated because of pagination problem. This problem was creating a security issue. The original was of paginating the objects was with the Laravel Eloquent pagination like $model->paginate(). However this method discards all the security controls added by Builder in AuthorizationRoles. That is why we manually implemented the pagination object.